### PR TITLE
chore(eslint): use new typescript-eslint shared configs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,9 +10,8 @@ module.exports = {
   extends: [
     'airbnb-base',
     'plugin:@eslint-community/eslint-comments/recommended',
-    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/strict-type-checked',
     'plugin:@typescript-eslint/stylistic-type-checked',
-    'plugin:@typescript-eslint/strict',
     'plugin:import/typescript',
     'plugin:perfectionist/recommended-natural',
     'prettier',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,8 +10,8 @@ module.exports = {
   extends: [
     'airbnb-base',
     'plugin:@eslint-community/eslint-comments/recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
     'plugin:@typescript-eslint/strict',
     'plugin:import/typescript',
     'plugin:perfectionist/recommended-natural',


### PR DESCRIPTION
Moves from `@typescript-eslint/eslint-plugin`'s old deprecated shared configs to the new ones as described in https://typescript-eslint.io/blog/announcing-typescript-eslint-v6/