### PR TITLE
style: enable rules for consistent type imports/exports, fix misc lint tasks

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,12 +60,10 @@ module.exports = {
   },
   root: true,
   rules: {
-    // Report on unused disable directives.
-    // This has the same effect as the `--report-unused-disable-directives` flag.
     '@eslint-community/eslint-comments/no-unused-disable': 'error',
-
-    // Turn off rules that potentially conflict with eslint-plugin-perfectionist.
     '@typescript-eslint/adjacent-overload-signatures': 'off',
+    '@typescript-eslint/consistent-type-exports': 'error',
+    '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/sort-type-constituents': 'off',
     'import/order': 'off',
     'react/jsx-sort-props': 'off',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -76,6 +76,7 @@ module.exports = {
       typescript: true,
     },
     react: {
+      formComponents: ['Form'],
       linkComponents: [
         {
           linkAttribute: 'to',

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -8,7 +8,7 @@
  * @type {Config}
  */
 const baseConfig = {
-  '*.{js,jsx,ts,tsx}': [
+  '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': [
     () => ['tsc --noEmit'],
     'eslint --cache --cache-location node_modules/.cache/eslint --fix',
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,6 @@
     "**/.*.mts",
     "**/*.mts",
     "**/*.tsx"
-  ]
+  ],
+  "exclude": ["node_modules", "./.cache", "./build", "./public/build"]
 }


### PR DESCRIPTION
* Enables ESLint rules for consistent type imports ([`@typescript-eslint/consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports)) and exports ([`@typescript-eslint/consistent-type-exports`](https://typescript-eslint.io/rules/consistent-type-exports)). See https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how for more details.
* Ensures Remix's `<Form>` is in the list of form components that `eslint-plugin-react` uses for various rules
* Fixes up the lint-staged tasks to apply to CommonJS-specific and ESM-specific JS and TS files
* Excludes git-ignored (built) directories from `tsc`'s type-checking